### PR TITLE
RFP: Shared blocklists of CIDs; Open proposal: CID commenting

### DIFF
--- a/open-grant-proposals/cid-commenting.md
+++ b/open-grant-proposals/cid-commenting.md
@@ -1,8 +1,6 @@
-To submit a proposal, please create a PR against this template in this repo. Please title your file `open-proposal-title.md`, replacing `title` with the name of your project.
+# Open Grant Proposal: `CID Commenting`
 
-# Open Grant Proposal: `Project Title`
-
-**Name of Project:**
+**Name of Project:** CID Commenting
 
 **Proposal Category:** `app-dev`
 

--- a/open-grant-proposals/cid-commenting.md
+++ b/open-grant-proposals/cid-commenting.md
@@ -1,0 +1,81 @@
+To submit a proposal, please create a PR against this template in this repo. Please title your file `open-proposal-title.md`, replacing `title` with the name of your project.
+
+# Open Grant Proposal: `Project Title`
+
+**Name of Project:**
+
+**Proposal Category:** `app-dev`
+
+**Proposer:** [@siman](https://github.com/siman)
+
+**Do you agree to open source all work you do on behalf of this RFP and dual-license under MIT and APACHE2 licenses?:** Yes, but we preffer GNU GPL v3.
+
+# Project Description
+
+The goal of this project is to create a decentralized platform on top of Substrate and IPFS that allows community to share interesting/important CIDs and comment on them. Think of it as a decentralized Reddit or Hacker News for IPFS.
+
+Additionally it would be cool to show replication factor of the CID content and this stats can be part of the feed algorithm for "trending" or something like this. Maybe we can make the interesting pages with the content sorted in descending order by replication factor. In this way people will see some most used or needed content in IFPS.
+
+## Value
+
+Please describe in more detail why this proposal is valuable for the Filecoin ecosystem. Answer the following questions:
+- What are the benefits to getting this right?
+- What are the risks if you don't get it right?
+- What are the risks that will make executing on this project difficult?
+
+This section should be 1-3 paragraphs long.
+
+## Deliverables
+
+- An open-sourced, dual-licensed (under MIT and APACHE2).
+- Working decentralized web app to manage share and comment CIDs.
+- Well-documented API for the service conforming to industry best practices. 
+- Video-tutorial with demo usage. 
+- Use Substrate and Rust on back-end and TypeScript on front-end.
+- Well-documented, human-readable codebase.
+
+## Development Roadmap
+
+WIP... more details soon.
+
+## Total Budget Requested
+
+$20000
+
+## Maintenance and Upgrade Plans
+
+We will maintenance and upgrade the solution such as we are planning to use it in Subsocial protocol.
+
+# Team
+
+## Team Members
+
+**Alex Siman** – Software Architect and Project Manager at Subsocial. Alex is a Polkadot Ambassador, a founder of “Polkadot Ukraine”. He has been building complex web apps since 2008. In 2017, he started to write smart contracts on Solidity and integrate them with dapps. Since 2019 he has been developing Substrate modules and building custom UIs for them with Polkadot API. Links: [GitHub](https://github.com/siman).
+
+**Oleg** – Front-end Developer (TypeScript, React). Oleg develops UI for Subsocial. His main contribution to this project can be found in Subsocial UI repo:
+https://github.com/dappforce/dappforce-subsocial-ui/commits?author=mell-old
+
+**Vlad** – Back-end Developer (Rust, C++). Vlad writes SRML and tests for Subsocial. His main contribution to this project can be found in Substrate runtime repo:
+https://github.com/dappforce/dappforce-subsocial-runtime/commits?author=F3Joule
+
+## Team Member LinkedIn Profiles
+
+[Alex Siman](https://www.linkedin.com/in/alexsiman/)
+
+Oleh and Vlad don't have LinkedIn accounts.
+
+## Team Website
+
+[DappForce dev team](https://github.com/dappforce)
+
+## Relevant Experience
+
+Alex Siman (the author of this proposal) is a founder and CTO of [Subsocial](http://subsocial.network/) – an open protocol for decentralized censorship-resistant social networks built with Substrate and IPFS. Our development is supported by **Web3 Foundation** grants program and we are particiapant of **Substrate Builders Program** from Parity. We already use IPFS in our architecture: when people write posts and comments, first, their content get stored in IPFS and then we create the entry for every post/comment in Substrate with provided IPFS CID of their content.
+
+## Team code repositories
+
+[DappForce](https://github.com/dappforce)
+
+# Additional Information
+
+[Subsocial protocol](http://subsocial.network)

--- a/rfp-proposals/rfp-proposal-shared-cid-blocklist.md
+++ b/rfp-proposals/rfp-proposal-shared-cid-blocklist.md
@@ -1,0 +1,67 @@
+# RFP Proposal: `Shared Blocklists of Content CIDs`
+
+**Name of Project:** Shared Blocklists of Content CIDs
+
+**Link to RFP:** [Shared Blocklists of Content CIDs](https://github.com/filecoin-project/devgrants/blob/master/rfps/new-wave-4-rfps.md#shared-blocklists-of-content-cids)
+`
+**RFP Category:** `app-dev`
+
+**Proposer:** [@siman](https://github.com/siman)
+
+**Do you agree to open source all work you do on behalf of this RFP and dual-license under MIT and APACHE2 licenses?:** Yes, but we preffer GNU GPL v3.
+
+# Project Description
+
+WIP... will commit a bit later.
+
+## Deliverables
+
+- An open-sourced, dual-licensed (under MIT and APACHE2).
+- Working decentralized web app to manage CID blocklists.
+- Well-documented API for the service conforming to industry best practices. 
+- Video-tutorial with demo usage. 
+- Use Substrate and Rust on back-end and TypeScript on front-end.
+- Well-documented, human-readable codebase.
+
+## Development Roadmap
+
+WIP... will commit a bit later.
+
+## Total Budget Requested
+
+$20000
+
+## Maintenance and Upgrade Plans
+
+We will maintenance and upgrade the solution such as we are planning to use it in Subsocial protocol.
+
+# Team
+
+## Team Members
+
+**Alex Siman** – Software Architect and Project Manager at Subsocial. Alex is a Polkadot Ambassador, a founder of “Polkadot Ukraine”. He has been building complex web apps since 2008. In 2017, he started to write smart contracts on Solidity and integrate them with dapps. Since 2019 he has been developing Substrate modules and building custom UIs for them with Polkadot API. Links: [GitHub](https://github.com/siman).
+
+**Oleg** – Front-end Developer (TypeScript, React). Oleg develops UI for Subsocial. His main contribution to this project can be found in Subsocial UI repo:
+https://github.com/dappforce/dappforce-subsocial-ui/commits?author=mell-old
+
+**Vlad** – Back-end Developer (Rust, C++). Vlad writes SRML and tests for Subsocial. His main contribution to this project can be found in Substrate runtime repo:
+https://github.com/dappforce/dappforce-subsocial-runtime/commits?author=F3Joule
+
+## Team Member LinkedIn Profiles
+
+[Alex Siman](https://www.linkedin.com/in/alexsiman/)
+
+## Team Website
+
+[DappForce dev team](https://github.com/dappforce)
+
+## Relevant Experience
+
+
+## Team code repositories
+
+[DappForce](https://github.com/dappforce)
+
+# Additional Information
+
+[Subsocial protocol](http://subsocial.network)

--- a/rfp-proposals/shared-cid-blocklist.md
+++ b/rfp-proposals/shared-cid-blocklist.md
@@ -12,7 +12,27 @@
 
 # Project Description
 
-WIP... will commit a bit later.
+The goal of this project is to create registry for sharing CID block lists on Substrate.
+
+We are going to keep the list of blocked CIDs in Substrate runtime storage.
+This will allow blockchain logic of Substrate modules (pallets) and smart contracts access the block lists
+and make their own decision whether they want to accept the CIDs that are blocked here or there.
+
+Such blocking functionality need specific extrinsics (transaction functions in terms of Substrate) to manage the lists of CIDs:
+- block_cids(space_id, cids)
+- unblock_cids(space_id, cids)
+- how many times has CID been blocked?
+- get the list of space ids that blocked this CID
+
+Additionally I would implement a management of trust list of CIDs.
+For example there could be some authorities that represent law enforcement of a country
+and maybe they will come up with decisions on some controversial CIDs.
+Then they would be able to add those CIDs to their space and others could refer to the trust lists when they are unsure about the CID.
+
+I would also make it possible to use an enum to specify a block reason: Spam, Child abuse, Hate speech, etc.
+Only having this info about trusted/blocked CIDs on chain would allow to use them in blockchain logic or in smart contracts on Substrate.
+
+Also we have created flexible Roles and Permissions modules where the space owner can specify what account could manage block lists. This is also an essential feature because it allows to create for example "Content Moderator" role, grant it to some accounts and they will be able to block and/or unblock and/or make trusted CIDs.
 
 ## Deliverables
 
@@ -51,12 +71,15 @@ https://github.com/dappforce/dappforce-subsocial-runtime/commits?author=F3Joule
 
 [Alex Siman](https://www.linkedin.com/in/alexsiman/)
 
+Oleh and Vlad don't have LinkedIn accounts.
+
 ## Team Website
 
 [DappForce dev team](https://github.com/dappforce)
 
 ## Relevant Experience
 
+Alex Siman (the author of this proposal) is a founder and CTO of [Subsocial](http://subsocial.network/) – an open protocol for decentralized censorship-resistant social networks built with Substrate and IPFS. Our development is supported by **Web3 Foundation** grants program and we are particiapant of **Substrate Builders Program** from Parity. We already use IPFS in our architecture: when people write posts and comments, first, their content get stored in IPFS and then we create the entry for every post/comment in Substrate with provided IPFS CID of their content.
 
 ## Team code repositories
 


### PR DESCRIPTION
_Accidentally I put two proposals (PRF and Open) in this PR. I think it would be much convenient to split the proposals into two separate PRs. What do you think?_

## RFP: Shared blocklists of CIDs

A registry for sharing CID block lists on Substrate. It should be possible to provide an optional metadata around the reasons for blocklisting. A way for community members (regular users) to report CIDs to blocklist would also be useful.

Category tag: `category:app-dev`
Grant type tag: `proposal-type:rfp`

## Open proposal: CID commenting

A decentralized platform on top of Substrate and IPFS that allows community to share interesting/important CIDs and comment on them. Think of it as a decentralized Reddit or Hacker News for IPFS.

We are planning to built this project on top of Subsocial - a protocol for decentralized social networks on top of Substrate and IPFS. Please check out an [alpha version of Subsocial](http://dapp.subsocial.network/). And here is a presentation of Subsocial at Sub0 online conference organized by Parity Technologies: https://www.youtube.com/watch?v=NeDSaNxAjj4

Tag: `category:app-dev`.
Grant type tag: `proposal-type:open`

