### PR TITLE
Fix link to categories in open grant application

### DIFF
--- a/.github/ISSUE_TEMPLATE/open-grant-application.md
+++ b/.github/ISSUE_TEMPLATE/open-grant-application.md
@@ -11,7 +11,7 @@ assignees: realChainLife
 
 **Name of Project:**
 
-**Proposal Category:** Choose one of `core-dev`, `app-dev`, `devtools-libraries`, `integration-adoption` , `technical-design`, `docs` , `community` , `metaverse` , `research` , `green`  Learn what these categories are here: {https://github.com/filecoin-project/devgrants/tree/master/open-grants}"
+**Proposal Category:** Choose one of `core-dev`, `app-dev`, `devtools-libraries`, `integration-adoption` , `technical-design`, `docs` , `community` , `metaverse` , `research` , `green`  Learn what these categories are here: https://github.com/filecoin-project/devgrants/tree/master/open-grants#readme
 
 **Proposer:** `replace with your GitHub username`
 


### PR DESCRIPTION
The link to the categories in the open grant application didn't work
due to a trailing curly bracket. This commit makes the link clickable
and also points it to the README anchor, which should make things
still generic enough, but a better user experience.