### PR TITLE
Remove the link to the old "accepted grants"-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This program is intended for early stage projects. If your project has already r
 Do you have an idea for pushing the Filecoin ecosystem forward? Grants of $10,000+ are available to support novel ideas that advance the Filecoin ecosystem, bring significant new usage, or directly advance the Filecoin mission statement.
 
 
-[**LEARN MORE ABOUT OPEN GRANTS**](https://github.com/filecoin-project/devgrants/tree/master/open-grants) **AND** [**APPLY FOR AN OPEN GRANT**](https://github.com/filecoin-project/devgrants/issues/new?assignees=&labels=&template=open-grant-application.md&title=) • [**See Accepted Open Grant Proposals**](https://github.com/filecoin-project/devgrants/blob/master/open-grants/accepted-open-grant-applications.md)
+[**LEARN MORE ABOUT OPEN GRANTS**](https://github.com/filecoin-project/devgrants/tree/master/open-grants) **AND** [**APPLY FOR AN OPEN GRANT**](https://github.com/filecoin-project/devgrants/issues/new?assignees=&labels=&template=open-grant-application.md&title=)
 
 
 ---


### PR DESCRIPTION
Hi there! I took a look at the old grants page (https://github.com/filecoin-project/devgrants/blob/master/open-grants/accepted-open-grant-applications.md) and it looks like we haven't updated it in a year. Should we remove the link? Or maybe refresh the page to only show a few exemplary grants for each of the categories that now exist? 